### PR TITLE
Implemented `Eq`, changed constructors `new` and `with_len`.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,43 @@
+name: Codecov
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "trunk", "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Download grcov
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.10/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Run xtask coverage
+        uses: actions-rs/cargo@v1
+        with:
+          command: xtask
+          args: coverage
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage/*.lcov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "trunk", "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - nightly
+          - 1.56
+
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
-# Change Log
+# Changelog
+
+
+## [v0.3.0] - 2021-04-14
+
+### Changed
+- Changed `DisjointSet::new` to take no arguments and construct an empty `DisjointSet`. 
+- Retained the old functionality of `DisjointSet::new` under the new name `DisjointSet::with_len`.
+
+### Added
+- Implemented `Eq` for `DisjointSet` and `DisjointSetVec`.
 
 ## [v0.2.0] - 2021-04-13
 
 ### Added
 - Implemented `Debug`, `Clone`, `PartialEq` and `Default` for `DisjointSet`.
-- Added `with_capacity`, `add_singleton`, `get_sets` to `DisjointSet`.  
+- Added `with_capacity`, `add_singleton`, and `get_sets` to `DisjointSet`.  
 - Added `DisjointSetVec`.
 
 ## [v0.1.0] - 2021-04-12
@@ -13,3 +23,4 @@
 
 [v0.1.0]: https://github.com/jogru0/disjoint/commit/15bb8dce2a5f33812fe237d19354a792612fd92c
 [v0.2.0]: https://github.com/jogru0/disjoint/compare/v0.1.0...v0.2.0
+[v0.3.0]: https://github.com/jogru0/disjoint/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# disjoint
+<h1 align="center">disjoint</h1>
 
-This crate provides fast [disjoint-set data structures] implementations in 100% safe Rust.
+[![Tests](https://github.com/jogru0/disjoint/actions/workflows/tests.yml/badge.svg)](https://github.com/jogru0/disjoint/actions)
+[![Codecov](https://codecov.io/gh/jogru0/disjoint/branch/trunk/graph/badge.svg?token=D910NJAG7K)](https://codecov.io/gh/jogru0/disjoint)
+[![Crate](https://img.shields.io/crates/v/disjoint.svg)](https://crates.io/crates/disjoint)
+
+This crate provides fast [disjoint-set data structure] implementations in 100% safe Rust.
 
 `DisjointSet` is a very lightweight disjoint-set data structure, with no additional data attached to the set elements. Use this if you manage the data associated to the elements yourself, and just want to keep track which elements are joined.
 
@@ -65,11 +69,15 @@ fn minimum_spanning_forest_quick_find<G : Graph>(graph: &G) -> G {
 
 See the [documentation] for more details on how these and other methods work.
 
-[disjoint-set data structures]: https://en.wikipedia.org/wiki/Disjoint-set_data_structure
+[disjoint-set data structure]: https://en.wikipedia.org/wiki/Disjoint-set_data_structure
 [undirected edge-weighted graph]: https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)#Weighted_graph
 [minimal spanning forest]: https://en.wikipedia.org/wiki/Minimum_spanning_tree
 [Kruskal’s algorithm]: https://en.wikipedia.org/wiki/Kruskal%27s_algorithm
 [documentation]: https://docs.rs/disjoint/latest/disjoint/struct.DisjointSet.html
+
+## [`Changelog`]
+
+[`Changelog`]: CHANGELOG.md
 
 ## License
 

--- a/src/disjoint_set_vec.rs
+++ b/src/disjoint_set_vec.rs
@@ -39,24 +39,28 @@ use crate::DisjointSet;
 /// assert!(ds.is_joined(0, 1));
 /// assert!(!ds.is_joined(0, 2));
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DisjointSetVec<T> {
     data: Vec<T>,
     sets: DisjointSet,
 }
 
 impl<T> Default for DisjointSetVec<T> {
+    #[inline]
+    #[must_use]
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl<T> From<Vec<T>> for DisjointSetVec<T> {
+    #[inline]
+    #[must_use]
     fn from(value: Vec<T>) -> Self {
         let len = value.len();
-        DisjointSetVec {
+        Self {
             data: value,
-            sets: DisjointSet::new(len),
+            sets: DisjointSet::with_len(len),
         }
     }
 }
@@ -93,6 +97,7 @@ impl<T> DisjointSetVec<T> {
     /// // ...but this may make the disjoint set reallocate
     /// ds.push("test");
     /// ```
+    #[inline]
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
@@ -113,11 +118,12 @@ impl<T> DisjointSetVec<T> {
     ///
     /// let mut ds: DisjointSetVec<i32> = DisjointSetVec::new();
     /// ```
+    #[inline]
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             data: Vec::new(),
-            sets: DisjointSet::new(0),
+            sets: DisjointSet::new(),
         }
     }
 
@@ -134,6 +140,7 @@ impl<T> DisjointSetVec<T> {
     /// ds.join(1, 2);
     /// assert_eq!(ds.len(), 4);
     /// ```
+    #[inline]
     #[must_use]
     pub fn len(&self) -> usize {
         self.data.len()
@@ -150,6 +157,7 @@ impl<T> DisjointSetVec<T> {
     /// assert_eq!(ds.get(1), Some(&40));
     /// assert_eq!(ds.get(3), None);
     /// ```
+    #[inline]
     #[must_use]
     pub fn get(&self, index: usize) -> Option<&T> {
         self.data.get(index)
@@ -168,6 +176,7 @@ impl<T> DisjointSetVec<T> {
     /// ds.push(2);
     /// assert!(!ds.is_empty());
     /// ```
+    #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
@@ -193,6 +202,7 @@ impl<T> DisjointSetVec<T> {
     /// assert_eq!(iterator.next(), Some(&30));
     /// assert_eq!(iterator.next(), None);
     /// ```
+    #[inline]
     pub fn iter(&self) -> Iter<'_, T> {
         self.data.iter()
     }
@@ -216,6 +226,7 @@ impl<T> DisjointSetVec<T> {
     /// assert_eq!(ds[1], 4);
     /// assert_eq!(ds[2], 3);
     /// ```
+    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         self.data.iter_mut()
     }
@@ -238,6 +249,7 @@ impl<T> DisjointSetVec<T> {
     /// assert!(!ds[1]);
     /// assert!(!ds.is_joined(0, 1));
     /// ```
+    #[inline]
     pub fn push(&mut self, value: T) {
         self.data.push(value);
         self.sets.add_singleton();
@@ -303,6 +315,7 @@ impl<T> DisjointSetVec<T> {
     /// ds.join(1, 2); // {'a', 'b', 'c', 'd'}
     /// assert!(ds.is_joined(0, 3));
     /// ```
+    #[inline]
     pub fn join(&mut self, first_index: usize, second_index: usize) -> bool {
         self.sets.join(first_index, second_index)
     }
@@ -320,6 +333,7 @@ impl<T> DisjointSetVec<T> {
     /// ds.join(3, 1); // {'a'}, {'b', 'd'}, {'c'}
     /// assert_eq!(ds.get_index_sets(), vec![vec![0], vec![1, 3], vec![2]]);
     /// ```
+    #[inline]
     #[must_use]
     pub fn get_index_sets(&self) -> Vec<Vec<usize>> {
         self.sets.get_sets()
@@ -329,12 +343,16 @@ impl<T> DisjointSetVec<T> {
 impl<T> Index<usize> for DisjointSetVec<T> {
     type Output = T;
 
+    #[inline]
+    #[must_use]
     fn index(&self, index: usize) -> &Self::Output {
         self.data.index(index)
     }
 }
 
 impl<T> IndexMut<usize> for DisjointSetVec<T> {
+    #[inline]
+    #[must_use]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         self.data.index_mut(index)
     }
@@ -344,6 +362,8 @@ impl<T> IntoIterator for DisjointSetVec<T> {
     type Item = <Vec<T> as IntoIterator>::Item;
     type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
 
+    #[inline]
+    #[must_use]
     fn into_iter(self) -> Self::IntoIter {
         IntoIterator::into_iter(self.data)
     }
@@ -353,6 +373,8 @@ impl<'a, T> IntoIterator for &'a DisjointSetVec<T> {
     type Item = <&'a Vec<T> as IntoIterator>::Item;
     type IntoIter = <&'a Vec<T> as IntoIterator>::IntoIter;
 
+    #[inline]
+    #[must_use]
     fn into_iter(self) -> Self::IntoIter {
         IntoIterator::into_iter(&self.data)
     }
@@ -362,6 +384,8 @@ impl<'a, T> IntoIterator for &'a mut DisjointSetVec<T> {
     type Item = <&'a mut Vec<T> as IntoIterator>::Item;
     type IntoIter = <&'a mut Vec<T> as IntoIterator>::IntoIter;
 
+    #[inline]
+    #[must_use]
     fn into_iter(self) -> Self::IntoIter {
         IntoIterator::into_iter(&mut self.data)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,49 @@
-#![forbid(unsafe_code)]
-#![warn(missing_docs)]
-#![warn(clippy::must_use_candidate)]
+#![forbid(unsafe_code, non_ascii_idents)]
+#![warn(
+    clippy::pedantic,
+    clippy::nursery,
+    clippy::cargo,
+    clippy::restriction,
+    rustdoc::all,
+    explicit_outlives_requirements,
+    keyword_idents,
+    let_underscore_drop,
+    macro_use_extern_crate,
+    meta_variable_misuse,
+    missing_abi,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    noop_method_call,
+    pointer_structural_match,
+    single_use_lifetimes,
+    trivial_casts,
+    trivial_numeric_casts,
+    unreachable_pub,
+    unsafe_op_in_unsafe_fn,
+    unused_crate_dependencies,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_lifetimes,
+    unused_macro_rules,
+    unused_qualifications,
+    unused_tuple_struct_fields,
+    variant_size_differences
+)]
+#![allow(
+    clippy::blanket_clippy_restriction_lints,
+    clippy::pub_use,
+    clippy::single_char_lifetime_names,
+    clippy::missing_docs_in_private_items,
+    clippy::std_instead_of_core,
+    clippy::implicit_return,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::integer_arithmetic,
+    clippy::missing_trait_methods
+)]
 
-//! This crate provides fast [disjoint-set data structures] implementations in 100% safe Rust.
+//! This crate provides fast [disjoint-set data structure] implementations in 100% safe Rust.
 //!
 //! [`DisjointSet`] is a very lightweight disjoint-set data structure, with no additional data attached to the set elements. Use this if you manage the data associated to the elements yourself, and just want to keep track which elements are joined.
 //!
@@ -45,7 +86,7 @@
 //!
 //! fn minimum_spanning_forest<G : Graph>(graph: &G) -> G {
 //!     let mut result_edges = Vec::new();
-//!     let mut vertices = DisjointSet::new(graph.number_vertices());
+//!     let mut vertices = DisjointSet::with_len(graph.number_vertices());
 //!
 //!     for edge in graph.edges_ordered_by_weight() {
 //!         if !vertices.is_joined(edge.first_vertex(), edge.second_vertex()) {
@@ -77,7 +118,7 @@
 //!
 //! fn minimum_spanning_forest_quick_find<G : Graph>(graph: &G) -> G {
 //!     let mut result_edges = Vec::new();
-//!     let mut vertices = DisjointSet::new(graph.number_vertices());
+//!     let mut vertices = DisjointSet::with_len(graph.number_vertices());
 //!
 //!     for edge in graph.edges_ordered_by_weight() {
 //!         if vertices.join(edge.first_vertex(), edge.second_vertex()) {
@@ -89,7 +130,7 @@
 //! }
 //! ```
 //!
-//! [disjoint-set data structures]: https://en.wikipedia.org/wiki/Disjoint-set_data_structure
+//! [disjoint-set data structure]: https://en.wikipedia.org/wiki/Disjoint-set_data_structure
 //! [undirected edge-weighted graph]: https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)#Weighted_graph
 //! [minimal spanning forest]: https://en.wikipedia.org/wiki/Minimum_spanning_tree
 //! [Kruskal’s algorithm]: https://en.wikipedia.org/wiki/Kruskal%27s_algorithm


### PR DESCRIPTION
- Changed `DisjointSet::new` to take no arguments and construct an empty `DisjointSet`.
- Retained the old functionality of `DisjointSet::new` under the new name `DisjointSet::with_len`.
- Implemented `Eq` for `DisjointSet` and `DisjointSetVec`.