### PR TITLE
Add a `clear` function to `DisjointSet` and `DisjointSetVec`.

### DIFF
--- a/src/disjoint_set.rs
+++ b/src/disjoint_set.rs
@@ -354,6 +354,30 @@ impl DisjointSet {
         }
     }
 
+    /// Clears the `DisjointSet`.
+    /// 
+    /// The disjoint set will retain its capacity, so adding elements will not
+    /// allocate.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use disjoint::DisjointSet;
+    ///
+    /// let mut set = DisjointSet::new();
+    /// set.add_singleton();
+    /// set.add_singleton();
+    /// set.clear();
+    /// assert_eq!(set.len(), 0);
+    /// // Does not allocate!
+    /// set.add_singleton();
+    /// ```
+    #[inline]
+    pub fn clear(&mut self) {
+        self.parents.clear();
+        self.ranks.clear();
+    }
+
     /// Returns a `Vec` of all sets. Each entry corresponds to one set, and is a `Vec` of its elements.
     ///
     /// The sets are ordered by their smallest contained element. The elements inside each sets are ordered.
@@ -433,5 +457,15 @@ mod test {
 
         assert_ne!(ds.parents[1], ds.parents[3]);
         assert!(!ds.join(1, 3));
+    }
+
+    #[test]
+    fn clear_removes_elements_without_removing_capacity() {
+        let mut set = DisjointSet::new();
+        set.add_singleton();
+        set.add_singleton();
+        let capacity = set.parents.capacity();
+        set.clear();
+        assert_eq!(set.parents.capacity(), capacity);
     }
 }

--- a/src/disjoint_set_vec.rs
+++ b/src/disjoint_set_vec.rs
@@ -178,6 +178,31 @@ impl<T> DisjointSetVec<T> {
         }
     }
 
+    /// Clears the `DisjointSetVec`.
+    /// 
+    /// The disjoint set will retain its capacity, so adding elements will not
+    /// allocate.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use disjoint::DisjointSetVec;
+    ///
+    /// let mut set = DisjointSetVec::new();
+    /// set.push(123);
+    /// set.push(456);
+    /// set.clear();
+    /// assert_eq!(set.values().len(), 0);
+    /// assert!(set.values().capacity() >= 2);
+    /// // Does not allocate!
+    /// set.push(789);
+    /// ```
+    #[inline]
+    pub fn clear(&mut self) {
+        self.data.clear();
+        self.indices.clear();
+    }
+
     /// Appends an element to the back of a collection, not joined to any other element.
     ///
     /// # Panics

--- a/tests/disjoint_set.rs
+++ b/tests/disjoint_set.rs
@@ -411,3 +411,13 @@ fn different_ways_of_empty_construction() {
     assert_eq!(empty_with_len, empty_new);
     assert_eq!(empty_with_len, empty_default);
 }
+
+#[test]
+fn clear_removes_elements() {
+    let mut set = DisjointSet::new();
+    set.add_singleton();
+    set.add_singleton();
+    assert_eq!(set.len(), 2);
+    set.clear();
+    assert_eq!(set.len(), 0);
+}


### PR DESCRIPTION
This allows emptying these containers without removing their capacity. This is useful if you are emptying it and then about to refill it with similarly-sized data.