### PR TITLE
Make `add_singleton` and `push` return the index of the new element.

### DIFF
--- a/src/disjoint_set.rs
+++ b/src/disjoint_set.rs
@@ -183,7 +183,8 @@ impl DisjointSet {
         }
     }
 
-    /// Adds a new element, not joined to any other element.
+    /// Adds a new element, not joined to any other element. Returns the index
+    /// of the new element.
     ///
     /// # Panics
     ///
@@ -195,14 +196,16 @@ impl DisjointSet {
     /// use disjoint::DisjointSet;
     ///
     /// let mut ds = DisjointSet::with_len(1);
-    /// ds.add_singleton();
+    /// assert_eq!(ds.add_singleton(), 1);
     /// assert_eq!(ds.len(), 2);
     /// assert!(!ds.is_joined(0, 1));
     /// ```
     #[inline]
-    pub fn add_singleton(&mut self) {
-        self.parents.push(Cell::new(self.len()));
+    pub fn add_singleton(&mut self) -> usize {
+        let id = self.len();
+        self.parents.push(Cell::new(id));
         self.ranks.push(0);
+        id
     }
 
     /// If `first_element` and `second_element` are in different sets, joins them together and returns `true`.

--- a/src/disjoint_set_vec.rs
+++ b/src/disjoint_set_vec.rs
@@ -178,7 +178,8 @@ impl<T> DisjointSetVec<T> {
         }
     }
 
-    /// Appends an element to the back of a collection, not joined to any other element.
+    /// Appends an element to the back of a collection, not joined to any other
+    /// element. Returns the index of the new element.
     ///
     /// # Panics
     ///
@@ -197,9 +198,9 @@ impl<T> DisjointSetVec<T> {
     /// assert!(!dsv.is_joined(0, 1));
     /// ```
     #[inline]
-    pub fn push(&mut self, value: T) {
+    pub fn push(&mut self, value: T) -> usize {
         self.data.push(value);
-        self.indices.add_singleton();
+        self.indices.add_singleton()
     }
 
     /// Returns the index of an element of the subset containing the element at `child_index`.

--- a/tests/disjoint_set.rs
+++ b/tests/disjoint_set.rs
@@ -352,9 +352,9 @@ fn add_singleton_produces_singleton() {
     let mut ds = DisjointSet::with_len(3);
     ds.join(0, 2);
     verify_subsets(&ds, &[vec![0, 2], vec![1]]);
-    ds.add_singleton();
+    assert_eq!(ds.add_singleton(), 3);
     verify_subsets(&ds, &[vec![0, 2], vec![1], vec![3]]);
-    ds.add_singleton();
+    assert_eq!(ds.add_singleton(), 4);
     verify_subsets(&ds, &[vec![0, 2], vec![1], vec![3], vec![4]]);
 }
 

--- a/tests/disjoint_set_vec.rs
+++ b/tests/disjoint_set_vec.rs
@@ -360,9 +360,9 @@ fn push_produces_singleton() {
     let mut dsv = disjoint_set_vec![-1, -2, -3];
     dsv.join(0, 2);
     verify_subsets(&dsv, &[vec![0, 2], vec![1]]);
-    dsv.push(0);
+    assert_eq!(dsv.push(0), 3);
     verify_subsets(&dsv, &[vec![0, 2], vec![1], vec![3]]);
-    dsv.push(0);
+    assert_eq!(dsv.push(0), 4);
     verify_subsets(&dsv, &[vec![0, 2], vec![1], vec![3], vec![4]]);
 }
 


### PR DESCRIPTION
The indices of elements can be derived from the len of the set, but it is inconvenient to have to start a whole new statement just to join the element to something else.

With this, we can now add an element and assign it in one step.

My concrete case is something like this:
```rust
let mut set = DisjointSet::new();
let mut key_to_index = HashMap::new();

// ...In some loop
let index = *key_to_index.entry(my_key).or_insert_with(|| set.add_singleton());
```